### PR TITLE
Stops babel from including polyfills

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = {
 					),
 					plugins: [
 						require.resolve('babel-plugin-add-module-exports'),
-						require.resolve('babel-plugin-transform-runtime'),
+						[require.resolve('babel-plugin-transform-runtime'), { polyfill: false }],
 						[require.resolve('babel-plugin-transform-es2015-classes'), { loose: true }]
 					]
 				}


### PR DESCRIPTION
We use the FT polyfill service so using the babel polyfill's causes
duplication.
