### PR TITLE
Read app specfic include paths from config file

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -16,11 +16,10 @@ module.exports = {
 				loader: require.resolve('babel-loader'),
 				include: [
 					/bower_components/,
-					/n-card/,
 					path.resolve(__dirname, 'client'),
 					path.resolve(__dirname, 'config'),
 					path.resolve(__dirname, 'shared')
-				],
+				].concat(config.includes || []),
 				query: {
 					cacheDirectory: true,
 					presets: (


### PR DESCRIPTION
Reads `includes` array form `n-makfile.json` configuration to avoid bloating the default configuration and allow consuming apps to specify their own custom module include paths.

/cc @matthew-andrews 
