### PR TITLE
Compress by default

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -70,9 +70,7 @@ module.exports = {
 		// Production
 		if (process.argv.indexOf('--dev') === -1) {
 			plugins.push(new DefinePlugin({ 'process.env': { 'NODE_ENV': '"production"' } }));
-			if (config.assets.compress !== false) {
-				plugins.push(new UglifyJsPlugin());
-			}
+			plugins.push(new UglifyJsPlugin());
 		}
 
 		return plugins;

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -48,6 +48,9 @@ module.exports = {
 			{
 				test: /\.scss$/,
 				loader: ExtractTextPlugin.extract(process.argv.indexOf('--dev') === -1
+					// COMPLEX: Must specify the outputStyle of Sass because if you don't and you use Sass with UglifyJSPlugin
+					// even if the test for the UglifyJsPlugin only matches CSS files it will magically switch Sass's outputStyle
+					// to compressed ¯\_(ツ)_/¯.
 					? `css?minimize&-autoprefixer&sourceMap!postcss-loader!sass?sourceMap&outputStyle=expanded&includePaths[]=${path.resolve(__dirname, './bower_components')}`
 					: `css!postcss-loader!sass?includePaths[]=${path.resolve(__dirname, './bower_components')}`
 				)

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -48,7 +48,7 @@ module.exports = {
 			{
 				test: /\.scss$/,
 				loader: ExtractTextPlugin.extract(process.argv.indexOf('--dev') === -1
-					? `css?minimize&-autoprefixer&sourceMap!postcss-loader!sass?sourceMap&includePaths[]=${path.resolve(__dirname, './bower_components')}`
+					? `css?minimize&-autoprefixer&sourceMap!postcss-loader!sass?sourceMap&outputStyle=expanded&includePaths[]=${path.resolve(__dirname, './bower_components')}`
 					: `css!postcss-loader!sass?includePaths[]=${path.resolve(__dirname, './bower_components')}`
 				)
 			},
@@ -70,7 +70,7 @@ module.exports = {
 		// Production
 		if (process.argv.indexOf('--dev') === -1) {
 			plugins.push(new DefinePlugin({ 'process.env': { 'NODE_ENV': '"production"' } }));
-			if (config.assets.compress) {
+			if (config.assets.compress !== false) {
 				plugins.push(new UglifyJsPlugin());
 			}
 		}


### PR DESCRIPTION
@ironsidevsquincy @phamann 

^^ This fixes the bug where uglifyjs would cause sass to compress and remove comments — including the autoprefixer ones.
