### PR TITLE
Allow: New UglifyJsPlugin instance to receive object arguments

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -77,7 +77,7 @@ module.exports = {
 		// Production
 		if (process.argv.indexOf('--dev') === -1) {
 			plugins.push(new DefinePlugin({ 'process.env': { 'NODE_ENV': '"production"' } }));
-			plugins.push(new UglifyJsPlugin(config.uglify || {}));
+			plugins.push(new UglifyJsPlugin({ 'compress': { 'warnings': false } }));
 			plugins.push(function() {
 				this.plugin('done', stats => {
 					const hashable = Object.keys(stats.compilation.assets)

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -77,7 +77,7 @@ module.exports = {
 		// Production
 		if (process.argv.indexOf('--dev') === -1) {
 			plugins.push(new DefinePlugin({ 'process.env': { 'NODE_ENV': '"production"' } }));
-			plugins.push(new UglifyJsPlugin());
+			plugins.push(new UglifyJsPlugin(config.uglify || {}));
 			plugins.push(function() {
 				this.plugin('done', stats => {
 					const hashable = Object.keys(stats.compilation.assets)


### PR DESCRIPTION
cc @matthew-andrews @ironsidevsquincy 

Re. `next-front-page` PR: https://github.com/Financial-Times/next-front-page/pull/706

Allow you to add the below (as an example) to an app's `n-makefile.json`, which is given as an argument to the new instance of `UglifyJsPlugin`:-

```
{
  "uglify": {
    "compress": {
      "warnings": false
    }
  }
}

```
