### PR TITLE
Check for the existence of the dependency object in package.json

### DIFF
--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -36,7 +36,9 @@ const config = {
 	'extends': []
 };
 
-if (require('./package.json').dependencies.react) {
+const packageJson = require('./package.json');
+
+if (packageJson.dependencies && packageJson.dependencies.react) {
 	config.plugins.push('react');
 	config.extends.push('plugin:react/recommended');
 


### PR DESCRIPTION
[next-myft-email](https://github.com/Financial-Times/next-myft-email/blob/master/package.json#L19) doesn't have any root-level dependencies, so parsing .eslintrc.js caused an error
