### PR TITLE
add nodemon.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ clea%:
 	@$(DONE)
 
 # install
-instal%: node_modules bower_components _install_scss_lint .editorconfig .eslintrc.js .scss-lint.yml .env webpack.config.js
+instal%: node_modules bower_components _install_scss_lint .editorconfig .eslintrc.js .scss-lint.yml .env webpack.config.js nodemon.json
 	@$(MAKE) $(foreach f, $(shell find functions/* -type d -maxdepth 0 2>/dev/null), $f/node_modules)
 	@$(DONE)
 
@@ -74,7 +74,7 @@ _install_scss_lint:
 	@if [ ! -x "$(shell which scss-lint)" ] && [ "$(shell $(call GLOB,'*.scss'))" != "" ]; then gem install scss-lint -v 0.35.0 && $(DONE); fi
 
 # Manage various dot/config files if they're in the .gitignore
-.editorconfig .eslintrc.js .scss-lint.yml webpack.config.js: n.Makefile
+.editorconfig .eslintrc.js .scss-lint.yml webpack.config.js nodemon.json: n.Makefile
 	@if $(call IS_GIT_IGNORED); then curl -sL https://raw.githubusercontent.com/Financial-Times/n-makefile/$(VERSION)/config/$@ > $@ && $(DONE); fi
 
 .env:

--- a/config/nodemon.json
+++ b/config/nodemon.json
@@ -1,0 +1,8 @@
+{
+	"ignoreRoot": [],
+	"watch": [
+		"node_modules",
+		"server",
+		"public"
+	]
+}


### PR DESCRIPTION
### Motivation

Every time I want to use `nodemon` instead of `node`, I'd have to copy in `nodemon.json`.
### Solution

Install `nodemon.json` as part of `make install`.

I'm not sure this solution a good idea.  There's still the hassle of including `nodemon.json` in `.gitignore` and pushing that up to origin.  There may be some people who don't use `nodemon` and see this as more a tooling choice, much like how including `.idea` in a project shouldn't happen. :-)

Let me have your opinion. I'll really appreciate it. :-)
