### PR TITLE
Revert "Allow spaces in env vars"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ _verify_scss_lint:
 # DEPLOY SUB-TASKS
 
 _deploy_apex:
-	@if [ -e project.json ]; then $(call CONFIG_VARS,production) | sed 's/\(.*\)/-s \1/' | tr '\n' ' ' | xargs -0 apex deploy && $(DONE); fi
+	@if [ -e project.json ]; then $(call CONFIG_VARS,production) | sed 's/\(.*\)/-s \1/' | tr '\n' ' ' | xargs apex deploy && $(DONE); fi
 
 # BUILD SUB-TASKS
 


### PR DESCRIPTION
Reverts Financial-Times/n-makefile#77

Now lambda deploy errors with noisy output even when I've removed the space from the env var! Gonna revert this before other lambda apps risk picking it up and we leak keys all over the shop

@matthew-andrews 
