### PR TITLE
Autoprefix iOS Safari >= 5

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -121,7 +121,7 @@ module.exports = {
 		outputStyle: 'expanded'
 	},
 	postcss: () => {
-		return [ autoprefixer({ browsers: ['> 1%', 'last 2 versions', 'ie >= 8', 'ff ESR', 'bb >= 7'] }) ];
+		return [ autoprefixer({ browsers: ['> 1%', 'last 2 versions', 'ie >= 8', 'ff ESR', 'bb >= 7', 'iOS >= 5'] }) ];
 	},
 	plugins: (() => {
 		const plugins = [


### PR DESCRIPTION
Fixes Safari front page layout bug: https://jira.ft.com/browse/NFT-478

Autoprefixer stopped doing iOS < 8 by default: https://twitter.com/autoprefixer/status/735228920279257088
