### PR TITLE
fix no definition error

### DIFF
--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -45,7 +45,8 @@ if (packageJson.dependencies && (packageJson.dependencies.react || packageJson.d
 	Object.assign(config.rules, {
 		'react/display-name': 0,
 		'react/prop-types': 0,
-		'react/no-danger': 0
+		'react/no-danger': 0,
+		'react/no-render-return-value': 0
 	});
 }
 


### PR DESCRIPTION
I get this:

`error| Definition for rule 'react/no-render-return-value' was not found (react/no-render-return-value)``

and this PR is to get rid of that error.
