### PR TITLE
add .env-unquoted which has unquoted values for use in Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ ENV_MSG_CANT_GET = "Cannot get config vars for this service.  Check you are adde
 .env:
 	@if $(call IS_GIT_IGNORED,^.env$); then echo $(ENV_MSG_UPDATING) && sed -i "" "s/.env/\*.env\*/g" .gitignore; fi
 	@if $(call IS_GIT_IGNORED,*.env*); then heroku auth:whoami &>/dev/null || (echo $(ENV_MSG_HEROKU_CLI) && rm .env && exit 1); fi
-	@if $(call IS_GIT_IGNORED,*.env*) && [ -e package.json ]; then ($(call CONFIG_VARS,development,env) > .env && $(DONE)) || (echo $(ENV_MSG_CANT_GET) && rm .env && exit 1); fi
+	@if $(call IS_GIT_IGNORED,*.env*) && [ -e package.json ]; then ($(call CONFIG_VARS,development,env) > .env && (cat .env | sed 's/"//g' > .env-unquoted) && $(DONE)) || (echo $(ENV_MSG_CANT_GET) && rm .env && exit 1); fi
 
 # VERIFY SUB-TASKS
 

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ ENV_MSG_CANT_GET = "Cannot get config vars for this service.  Check you are adde
 .env:
 	@if $(call IS_GIT_IGNORED,^.env$); then echo $(ENV_MSG_UPDATING) && sed -i "" "s/.env/\*.env\*/g" .gitignore; fi
 	@if $(call IS_GIT_IGNORED,*.env*); then heroku auth:whoami &>/dev/null || (echo $(ENV_MSG_HEROKU_CLI) && rm .env && exit 1); fi
-	@if $(call IS_GIT_IGNORED,*.env*) && [ -e package.json ]; then ($(call CONFIG_VARS,development,env) > .env && sed -i '' 's/="\(.*\)"$$/=\1/g' .env && $(DONE)) || (echo $(ENV_MSG_CANT_GET) && rm .env && exit 1); fi
+	@if $(call IS_GIT_IGNORED,*.env*) && [ -e package.json ]; then ($(call CONFIG_VARS,development,env) > .env && perl -pi -e 's/="(.*)"/=\1/' .env && $(DONE)) || (echo $(ENV_MSG_CANT_GET) && rm .env && exit 1); fi
 
 # VERIFY SUB-TASKS
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 # Submit PR's here: https://www.github.com/Financial-Times/n-makefile
 
 
+# Setup environment variables
+sinclude .env
+export $(shell [ -f .env ] && sed 's/=.*//' .env)
+
 # ./node_modules/.bin on the PATH
 export PATH := ./node_modules/.bin:$(PATH)
 
@@ -102,7 +106,7 @@ ENV_MSG_CANT_GET = "Cannot get config vars for this service.  Check you are adde
 .env:
 	@if $(call IS_GIT_IGNORED,^.env$); then echo $(ENV_MSG_UPDATING) && sed -i "" "s/.env/\*.env\*/g" .gitignore; fi
 	@if $(call IS_GIT_IGNORED,*.env*); then heroku auth:whoami &>/dev/null || (echo $(ENV_MSG_HEROKU_CLI) && rm .env && exit 1); fi
-	@if $(call IS_GIT_IGNORED,*.env*) && [ -e package.json ]; then ($(call CONFIG_VARS,development,env) > .env && (cat .env | sed 's/"//g' > .env-unquoted) && $(DONE)) || (echo $(ENV_MSG_CANT_GET) && rm .env && exit 1); fi
+	@if $(call IS_GIT_IGNORED,*.env*) && [ -e package.json ]; then ($(call CONFIG_VARS,development,env) > .env && sed -i '' 's/="\(.*\)"$$/=\1/g' .env && $(DONE)) || (echo $(ENV_MSG_CANT_GET) && rm .env && exit 1); fi
 
 # VERIFY SUB-TASKS
 


### PR DESCRIPTION
for example:

`FOO_KEY="1234abcd"`

becomes:

`FOO_KEY=1234abcd`

which is suitable for use as environment variables exported from Makefiles.

I think we should even include this at the top of n.Makefile (maybe a separate PR):

```
# setup environment variables including AWS credentials
-include .env-unquoted
export $(shell [ -f .env-unquoted ] && sed 's/=.*//' .env-unquoted)
```

The minus trick there ensures that it won't fall over if `.env-unquoted` doesn't exist. The two lines combined will export all keys in `.env-unquoted` ready for any targets to use.
