### PR TITLE
Update .eslintrc.js

### DIFF
--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -23,7 +23,7 @@ const config = {
 		'no-unused-vars': 2,
 		'no-var': 2,
 		'one-var': [2, 'never'],
-		'quotes': [2, 'single'],
+		'quotes': [2, 'single', { 'avoidEscape': true }],
 		'space-before-function-paren': [2, 'always'],
 		'wrap-iife': 2
 	},


### PR DESCRIPTION
@ironsidevsquincy thoughts?

Updating linting and it errors for this:
`"['title','description','brand','duration']"`
But personally I think that's much more readable than 
`'[\'title\',\'description\',\'brand\',\'duration\']'`
