### PR TITLE
Help target

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -13,7 +13,7 @@ In `n-makefile` we have two main types of rules.  Common and sub.
 
 - If we permit the rule to be overwritten it may end with % instead of its final letter, allowing it to be overwritten without producing warnings. (this is a hack, of course, and means we have to be careful about how we name our common rules!)
 - By convention, app/component Makefiles make call commonrulename-super from inside their override to run the parent common rule functionality.
-- Include a comment describing the rule that the `help` rule will pickup using the following convention:
+- Include a comment using the following convention for it to be automatically parsed by the `help` rule:
 
 ```make
 rule-nam%: ## rule-name: Rule description.

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -13,6 +13,11 @@ In `n-makefile` we have two main types of rules.  Common and sub.
 
 - If we permit the rule to be overwritten it may end with % instead of its final letter, allowing it to be overwritten without producing warnings. (this is a hack, of course, and means we have to be careful about how we name our common rules!)
 - By convention, app/component Makefiles make call commonrulename-super from inside their override to run the parent common rule functionality.
+- Include a comment describing the rule that the `help` rule will pickup using the following convention:
+
+```make
+rule-nam%: ## rule-name: Rule description.
+```
 
 ### ‘Sub’ rule conventions
 

--- a/Makefile
+++ b/Makefile
@@ -27,42 +27,45 @@ CONFIG_VARS = curl -fsL https://ft-next-config-vars.herokuapp.com/$1/$(call APP_
 # META TASKS
 #
 
-.PHONY: test
+.PHONY: test help
+.SILENT: help
 
 #
 # COMMON TASKS
 #
 
-# clean
+clean: ## Clean this git repository.
 clea%:
 # HACK: Can't use -e option here because it's not supported by our Jenkins
 	@git clean -fxd
 	@$(DONE)
 
-# install
+install: ## Setup this repository.
 instal%: node_modules bower_components _install_scss_lint .editorconfig .eslintrc.js .scss-lint.yml .env webpack.config.js heroku-cli
 	@$(MAKE) $(foreach f, $(shell find functions/* -type d -maxdepth 0 2>/dev/null), $f/node_modules $f/bower_components)
 	@$(DONE)
 
-# deploy
+deploy: ## Deploy this repository.
 deplo%: _deploy_apex
 	@$(DONE)
 
-# verify
+verify: ## Verify this repository.
 verif%: _verify_lintspaces _verify_eslint _verify_scss_lint
 	@$(DONE)
 
-# assets (includes assets-production)
+assets: ## Build the static assets.
+assets-production: ## Build the static assets for production.
 asset%:
 	@if [ -e webpack.config.js ]; then webpack $(if $(findstring assets-production,$@),--bail,--dev); fi
 
-# build (includes build-production)
+build: ## Build this repository.
+build-production: ## Build this repository for production.
 buil%: public/__about.json
 	@if [ -e webpack.config.js ]; then $(MAKE) $(subst build,assets,$@); fi
 	@if [ -e Procfile ] && [ "$(findstring build-production,$@)" == "build-production" ]; then haikro build; fi
 	@$(DONE)
 
-# watch
+watch: ## Watch for static asset changes.
 watc%:
 	@if [ -e webpack.config.js ]; then webpack --watch --dev; fi
 	@$(DONE)
@@ -138,8 +141,7 @@ npm-publis%:
 public/__about.json:
 	@if [ -e Procfile ]; then mkdir -p public && echo '{"description":"$(call APP_NAME)","support":"next.team@ft.com","supportStatus":"active","appVersion":"$(shell git rev-parse HEAD | xargs echo -n)","buildCompletionTime":"$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")"}' > $@ && $(DONE); fi
 
-# UPDATE TASK
-update-tools:
+update-tools: ## Update this Makefile.
 	$(eval LATEST = $(shell curl -fs https://api.github.com/repos/Financial-Times/n-makefile/tags | $(call JSON_GET_VALUE,name)))
 	$(if $(filter $(LATEST), $(VERSION)), $(error Cannot update n-makefile, as it is already up to date!))
 	@curl -sL https://raw.githubusercontent.com/Financial-Times/n-makefile/$(LATEST)/Makefile > n.Makefile
@@ -147,3 +149,9 @@ update-tools:
 	@read -p "Updated tools from $(VERSION) to $(LATEST).  Do you want to commit and push? [y/N] " Y;\
 	if [ $$Y == "y" ]; then git add n.Makefile && git commit -m "Updated tools to $(LATEST)" && git push origin HEAD; fi
 	@$(DONE)
+	
+help: ## Show this help message.
+	echo "usage: make [target] ..."
+	echo ""
+	echo "targets:"
+	fgrep --no-filename "##" ${MAKEFILE_LIST} | head -n '-1' | column -s ':#' -t -c 2

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ CONFIG_VARS = curl -fsL https://ft-next-config-vars.herokuapp.com/$1/$(call APP_
 # META TASKS
 #
 
-.PHONY: test hel%
+.PHONY: test
 
 #
 # COMMON TASKS

--- a/Makefile
+++ b/Makefile
@@ -150,4 +150,4 @@ hel%: ## help: Show this help message.
 	@echo "usage: make [target] ..."
 	@echo ""
 	@echo "targets:"
-	@fgrep -h "##" ${MAKEFILE_LIST} | head -n '-1' | cut -d ' ' -f '3-' | column -t -s ':'
+	@grep -Eh '^.+:\ ##\ .+' ${MAKEFILE_LIST} | cut -d ' ' -f '3-' | column -t -s ':'

--- a/Makefile
+++ b/Makefile
@@ -27,46 +27,42 @@ CONFIG_VARS = curl -fsL https://ft-next-config-vars.herokuapp.com/$1/$(call APP_
 # META TASKS
 #
 
-.PHONY: test help
-.SILENT: help
+.PHONY: test hel%
 
 #
 # COMMON TASKS
 #
 
-clean: ## Clean this git repository.
-clea%:
+clea%: ## clean: Clean this git repository.
 # HACK: Can't use -e option here because it's not supported by our Jenkins
 	@git clean -fxd
 	@$(DONE)
 
-install: ## Setup this repository.
+instal%: ## install: Setup this repository.
 instal%: node_modules bower_components _install_scss_lint .editorconfig .eslintrc.js .scss-lint.yml .env webpack.config.js heroku-cli
 	@$(MAKE) $(foreach f, $(shell find functions/* -type d -maxdepth 0 2>/dev/null), $f/node_modules $f/bower_components)
 	@$(DONE)
 
-deploy: ## Deploy this repository.
+deplo%: ## deploy: Deploy this repository.
 deplo%: _deploy_apex
 	@$(DONE)
 
-verify: ## Verify this repository.
+verif%: ## verify: Verify this repository.
 verif%: _verify_lintspaces _verify_eslint _verify_scss_lint
 	@$(DONE)
 
-assets: ## Build the static assets.
-assets-production: ## Build the static assets for production.
-asset%:
+asset%: ## assets: Build the static assets.
+asset%: ## assets-production: Build the static assets for production.
 	@if [ -e webpack.config.js ]; then webpack $(if $(findstring assets-production,$@),--bail,--dev); fi
 
-build: ## Build this repository.
-build-production: ## Build this repository for production.
+buil%: ## build: Build this repository.
+buil%: ## build: Build this repository for production.
 buil%: public/__about.json
 	@if [ -e webpack.config.js ]; then $(MAKE) $(subst build,assets,$@); fi
 	@if [ -e Procfile ] && [ "$(findstring build-production,$@)" == "build-production" ]; then haikro build; fi
 	@$(DONE)
 
-watch: ## Watch for static asset changes.
-watc%:
+watc%: ## watch: Watch for static asset changes.
 	@if [ -e webpack.config.js ]; then webpack --watch --dev; fi
 	@$(DONE)
 
@@ -131,7 +127,7 @@ _deploy_apex:
 	@if [ -e project.json ]; then $(call CONFIG_VARS,production) > $(APEX_PROD_ENV_FILE) && apex deploy --env-file $(APEX_PROD_ENV_FILE); fi
 	@if [ -e $(APEX_PROD_ENV_FILE) ]; then rm $(APEX_PROD_ENV_FILE) && $(DONE); fi
 
-npm-publis%:
+npm-publis%: ## npm-publish: Publish this package to npm.
 	npm-prepublish --verbose
 	npm publish --access public
 
@@ -141,7 +137,7 @@ npm-publis%:
 public/__about.json:
 	@if [ -e Procfile ]; then mkdir -p public && echo '{"description":"$(call APP_NAME)","support":"next.team@ft.com","supportStatus":"active","appVersion":"$(shell git rev-parse HEAD | xargs echo -n)","buildCompletionTime":"$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")"}' > $@ && $(DONE); fi
 
-update-tools: ## Update this Makefile.
+update-tools: ## update-tools: Update this Makefile.
 	$(eval LATEST = $(shell curl -fs https://api.github.com/repos/Financial-Times/n-makefile/tags | $(call JSON_GET_VALUE,name)))
 	$(if $(filter $(LATEST), $(VERSION)), $(error Cannot update n-makefile, as it is already up to date!))
 	@curl -sL https://raw.githubusercontent.com/Financial-Times/n-makefile/$(LATEST)/Makefile > n.Makefile
@@ -150,8 +146,8 @@ update-tools: ## Update this Makefile.
 	if [ $$Y == "y" ]; then git add n.Makefile && git commit -m "Updated tools to $(LATEST)" && git push origin HEAD; fi
 	@$(DONE)
 	
-help: ## Show this help message.
-	echo "usage: make [target] ..."
-	echo ""
-	echo "targets:"
-	fgrep --no-filename "##" ${MAKEFILE_LIST} | head -n '-1' | column -s ':#' -t -c 2
+hel%: ## help: Show this help message.
+	@echo "usage: make [target] ..."
+	@echo ""
+	@echo "targets:"
+	@fgrep -h "##" ${MAKEFILE_LIST} | head -n '-1' | cut -d ' ' -f '3-' | column -t -s ':'

--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ For Heroku apps (i.e. if a `Procfile` exists):-
 
 Updates your project's copy of `n-makefile` to the latest version.
 
+### `help`
+
+Prints usage information for the rules defined in the Makefile.
+
+Add your own descriptions by commenting your rules like so:
+
+```make
+rule-%: ## rule-name: Rule description.
+```
+
 ## Contribution
 
 Please read the [contribution guide](./CONTRIBUTION.md).


### PR DESCRIPTION
An initial pass at adding a help target.

There's a comment convention for it to pickup targets to list:

```make
target-name: ## Target description.
```

Should look something like the following:

```
$ make help
usage: make [target] ...

targets:
aws-policy-test        Test
clean                  Clean this git repository.
install                Setup this repository.
deploy                 Deploy this repository.
verify                 Verify this repository.
assets                 Build the static assets.
assets-production      Build the static assets for production.
build                  Build this repository.
build-production       Build this repository for production.
watch                  Watch for static asset changes.
update-tools           Update this Makefile.
help                   Show this help message.
```

Seems to work as expected, but only done a little bit of manual Q&A.