### PR TITLE
move pa11yci to n.Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,11 @@ deplo%: _deploy_apex
 	@$(DONE)
 
 verif%: ## verify: Verify this repository.
-verif%: _verify_lintspaces _verify_eslint _verify_scss_lint _verify_pa11y
+verif%: _verify_lintspaces _verify_eslint _verify_scss_lint
+	@$(DONE)
+
+a11%: ## a11y: Check accessibility for this repository.
+a11%: _run_pa11y
 	@$(DONE)
 
 asset%: ## assets: Build the static assets.
@@ -107,6 +111,9 @@ MSG_HEROKU_CLI = "Please make sure the Heroku CLI toolbelt is installed - see ht
 heroku-cli:
 	@if [ -e Procfile ]; then heroku auth:whoami &>/dev/null || (echo $(MSG_HEROKU_CLI) && exit 1); fi
 
+# a11y:
+# 	@export TEST_URL="local.ft.com:3002"; pa11y-ci
+
 # VERIFY SUB-TASKS
 
 _verify_eslint:
@@ -119,12 +126,9 @@ _verify_scss_lint:
 # HACK: Use backticks rather than xargs because xargs swallow exit codes (everything becomes 1 and stoopidly scss-lint exits with 1 if warnings, 2 if errors)
 	@if [ -e .scss-lint.yml ]; then { scss-lint -c ./.scss-lint.yml `$(call GLOB,'*.scss')`; if [ $$? -ne 0 -a $$? -ne 1 ]; then exit 1; fi; $(DONE); } fi
 
-_verify_pa11y:
-	@if [ -e .pa11yci.js ]; then {
-
-	IF DEVELOPING LOCALLY DO: @export TEST_URL="local.ft.com:3002"; pa11y-ci
-	IF CI DO: @export TEST_URL=http://${TEST_APP}.herokuapp.com; pa11y-ci IF APP IS DEPLOYED YET WHEN WE DO VERIFY??
-}
+_run_pa11y:
+	@if [ TEST_APP has a number in it ]; @export TEST_URL=http://${TEST_APP}.herokuapp.com; pa11y-ci; fi
+	@if [ TEST_APP does not have a number in it]; @export TEST_URL="local.ft.com:3002"; pa11y-ci; fi
 
 # DEPLOY SUB-TASKS
 

--- a/Makefile
+++ b/Makefile
@@ -110,9 +110,6 @@ MSG_HEROKU_CLI = "Please make sure the Heroku CLI toolbelt is installed - see ht
 heroku-cli:
 	@if [ -e Procfile ]; then heroku auth:whoami &>/dev/null || (echo $(MSG_HEROKU_CLI) && exit 1); fi
 
-
-
-
 # VERIFY SUB-TASKS
 
 _verify_eslint:

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,11 @@ _install_scss_lint:
 
 .env:
 	@if $(call IS_GIT_IGNORED); then heroku auth:whoami &>/dev/null || (echo Please make sure the Heroku CLI is installed and authenticated by running ‘heroku auth:token’.  See more https://toolbelt.heroku.com/. && exit 1); fi
-	@if $(call IS_GIT_IGNORED) && [ -e package.json ]; then ($(call CONFIG_VARS,development) > .env && $(DONE)) || (echo "Cannot get config vars for this service.  Check you are added to the ft-next-config-vars service on Heroku with operate permissions.  Do that here - https://docs.google.com/spreadsheets/d/1mbJQYJOgXAH2KfgKUM1Vgxq8FUIrahumb39wzsgStu0 (or ask someone to do it for you).  Check that your package.json's name property is correct.  Check that your project has config-vars set up in models/development.js." && exit 1); fi
+	@if $(call IS_GIT_IGNORED) && [ -e package.json ]; then ($(call CONFIG_VARS,development) > .env && $(DONE)) || (echo "Cannot get config vars for this service. Check the name of your app in package.json matches its name in Heroku. Also check you are added to the ft-next-config-vars service on Heroku with operate permissions.  Do that here - https://docs.google.com/spreadsheets/d/1mbJQYJOgXAH2KfgKUM1Vgxq8FUIrahumb39wzsgStu0 (or ask someone to do it for you).  Check that your package.json's name property is correct.  Check that your project has config-vars set up in models/development.js." && exit 1); fi
+
+.pa11yci:
+	curl -sL https://raw.githubusercontent.com/Financial-Times/n-heroku-tools/master/n.Makefile/config/.pa11yci.js > .pa11yci.js
+
 
 # VERIFY SUB-TASKS
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ clea%: ## clean: Clean this git repository.
 	@$(DONE)
 
 instal%: ## install: Setup this repository.
-instal%: node_modules bower_components _install_scss_lint .editorconfig .eslintrc.js .scss-lint.yml .env webpack.config.js heroku-cli
+instal%: node_modules bower_components _install_scss_lint .editorconfig .eslintrc.js .scss-lint.yml .env .pa11yci webpack.config.js heroku-cli
 	@$(MAKE) $(foreach f, $(shell find functions/* -type d -maxdepth 0 2>/dev/null), $f/node_modules $f/bower_components)
 	@$(DONE)
 
@@ -48,7 +48,7 @@ deplo%: _deploy_apex
 	@$(DONE)
 
 verif%: ## verify: Verify this repository.
-verif%: _verify_lintspaces _verify_eslint _verify_scss_lint
+verif%: _verify_lintspaces _verify_eslint _verify_scss_lint _verify_pa11y
 	@$(DONE)
 
 asset%: ## assets: Build the static assets.
@@ -121,6 +121,13 @@ _verify_lintspaces:
 _verify_scss_lint:
 # HACK: Use backticks rather than xargs because xargs swallow exit codes (everything becomes 1 and stoopidly scss-lint exits with 1 if warnings, 2 if errors)
 	@if [ -e .scss-lint.yml ]; then { scss-lint -c ./.scss-lint.yml `$(call GLOB,'*.scss')`; if [ $$? -ne 0 -a $$? -ne 1 ]; then exit 1; fi; $(DONE); } fi
+
+_verify_pa11y:
+	@if [ -e .pa11yci.js ]; then {
+
+	IF DEVELOPING LOCALLY DO: @export TEST_URL="local.ft.com:3002"; pa11y-ci
+	IF CI DO: @export TEST_URL=http://${TEST_APP}.herokuapp.com; pa11y-ci IF APP IS DEPLOYED YET WHEN WE DO VERIFY??
+}
 
 # DEPLOY SUB-TASKS
 

--- a/Makefile
+++ b/Makefile
@@ -96,15 +96,12 @@ _install_scss_lint:
 	@if [ ! -x "$(shell which scss-lint)" ] && [ "$(shell $(call GLOB,'*.scss'))" != "" ]; then gem install scss-lint -v 0.35.0 && $(DONE); fi
 
 # Manage various dot/config files if they're in the .gitignore
-.editorconfig .eslintrc.js .scss-lint.yml webpack.config.js: n.Makefile
+.editorconfig .eslintrc.js .scss-lint.yml webpack.config.js .pa11yci.js: n.Makefile
 	@if $(call IS_GIT_IGNORED); then curl -sL https://raw.githubusercontent.com/Financial-Times/n-makefile/$(VERSION)/config/$@ > $@ && $(DONE); fi
 
 ENV_MSG_CANT_GET = "Cannot get config vars for this service.  Check you are added to the ft-next-config-vars service on Heroku with operate permissions.  Do that here - https://docs.google.com/spreadsheets/d/1mbJQYJOgXAH2KfgKUM1Vgxq8FUIrahumb39wzsgStu0 (or ask someone to do it for you).  Check that your package.json's name property is correct.  Check that your project has config-vars set up in models/development.js."
 .env:
 	@if $(call IS_GIT_IGNORED,*.env*) && [ -e package.json ] && [ -z $(CIRCLECI) ]; then ($(call CONFIG_VARS,development,env) > .env && perl -pi -e 's/="(.*)"/=\1/' .env && $(DONE)) || (echo $(ENV_MSG_CANT_GET) && rm .env && exit 1); fi
-
-.pa11yci:
-	curl -sL https://raw.githubusercontent.com/Financial-Times/n-heroku-tools/master/n.Makefile/config/.pa11yci.js > .pa11yci.js
 
 MSG_HEROKU_CLI = "Please make sure the Heroku CLI toolbelt is installed - see https://toolbelt.heroku.com/. And make sure you are authenticated by running ‘heroku login’. If this is not an app, delete Procfile."
 heroku-cli:

--- a/Makefile
+++ b/Makefile
@@ -111,9 +111,6 @@ MSG_HEROKU_CLI = "Please make sure the Heroku CLI toolbelt is installed - see ht
 heroku-cli:
 	@if [ -e Procfile ]; then heroku auth:whoami &>/dev/null || (echo $(MSG_HEROKU_CLI) && exit 1); fi
 
-# a11y:
-# 	@export TEST_URL="local.ft.com:3002"; pa11y-ci
-
 # VERIFY SUB-TASKS
 
 _verify_eslint:
@@ -127,8 +124,11 @@ _verify_scss_lint:
 	@if [ -e .scss-lint.yml ]; then { scss-lint -c ./.scss-lint.yml `$(call GLOB,'*.scss')`; if [ $$? -ne 0 -a $$? -ne 1 ]; then exit 1; fi; $(DONE); } fi
 
 _run_pa11y:
-	@if [ TEST_APP has a number in it ]; @export TEST_URL=http://${TEST_APP}.herokuapp.com; pa11y-ci; fi
-	@if [ TEST_APP does not have a number in it]; @export TEST_URL="local.ft.com:3002"; pa11y-ci; fi
+ifdef $(CIRCLE_BRANCH)
+	@export TEST_URL=http://${TEST_APP}.herokuapp.com; pa11y-ci;
+else
+	@export TEST_URL=http://local.ft.com:3002; pa11y-ci;
+endif
 
 # DEPLOY SUB-TASKS
 

--- a/config/.pa11yci.js
+++ b/config/.pa11yci.js
@@ -25,29 +25,6 @@ const smoke = require('./test/smoke.js');
 
 const urls = [];
 
-smoke.forEach((config) => {
-	for (url in config.urls) {
-
-		// Fragments and components, not real pages
-		const exception = url.indexOf('fragment=true') !== -1 || url.indexOf('embedded-components') !== -1 || url.indexOf('story-package') !== -1 || url.indexOf('count=') !== -1;
-
-		if (config.urls[url] !== 200 || url === '/__health' || exception) {
-			continue;
-		}
-
-		const thisUrl = {
-			url: process.env.TEST_URL + url
-		}
-
-		if (config.headers) {
-			thisUrl.headers = config.headers
-		}
-
-		urls.push(thisUrl)
-	}
-});
-
-
 const config = {
 	defaults: {
 		page: {
@@ -57,8 +34,35 @@ const config = {
 		},
 		timeout: 50000
 	},
-	urls: []
+	urls: [],
+	exceptions: []
 }
+
+smoke.forEach((smokeConfig) => {
+	for (url in smokeConfig.urls) {
+
+		let isException = false;
+
+		config.exceptions.forEach((path) => {
+			isException = isException || url.indexOf(path) !== -1;
+		});
+
+		if (smokeConfig.urls[url] !== 200 || url === '/__health' || isException) {
+			continue;
+		}
+
+		const thisUrl = {
+			url: process.env.TEST_URL + url
+		}
+
+		if (smokeConfig.headers) {
+			thisUrl.headers = smokeConfig.headers
+		}
+
+		urls.push(thisUrl)
+	}
+});
+
 
 for (viewport of viewports) {
 	for (url of urls) {
@@ -68,3 +72,4 @@ for (viewport of viewports) {
 }
 
 module.exports = config;
+fas

--- a/config/.pa11yci.js
+++ b/config/.pa11yci.js
@@ -1,0 +1,70 @@
+const viewports = [
+	{
+		width: 1440,
+		height: 1220
+	},
+	{
+		width: 1220,
+		height: 980
+	},
+	{
+		width: 980,
+		height: 740
+	},
+	{
+		width: 740,
+		height: 490
+	},
+	{
+		width: 490,
+		height: 740
+	}
+];
+
+const smoke = require('./test/smoke.js');
+
+const urls = [];
+
+smoke.forEach((config) => {
+	for (url in config.urls) {
+
+		// Fragments and components, not real pages
+		const exception = url.indexOf('fragment=true') !== -1 || url.indexOf('embedded-components') !== -1 || url.indexOf('story-package') !== -1 || url.indexOf('count=') !== -1;
+
+		if (config.urls[url] !== 200 || url === '/__health' || exception) {
+			continue;
+		}
+
+		const thisUrl = {
+			url: process.env.TEST_URL + url
+		}
+
+		if (config.headers) {
+			thisUrl.headers = config.headers
+		}
+
+		urls.push(thisUrl)
+	}
+});
+
+
+const config = {
+	defaults: {
+		page: {
+			headers: {
+				"Cookie": "next-flags=ads:off,cookieMessage:off; secure=true"
+			}
+		},
+		timeout: 50000
+	},
+	urls: []
+}
+
+for (viewport of viewports) {
+	for (url of urls) {
+		url.viewport = viewport;
+		config.urls.push(url);
+	}
+}
+
+module.exports = config;


### PR DESCRIPTION
proof of concept

This gets `.pa11yci.js` into nht and gets it pulled into the individual apps by running make `.pa11yci`

Then each app is responsible for overriding things like cookies... haven't thought that part through yet, but it'd be outside of n.Makefile

@TheoLeanse @GlynnPhillips 