### PR TITLE
[DO NOT MERGE] Add: verifyPage property + value (env var) to URLs in pa11yci

### DIFF
--- a/config/.pa11yci.js
+++ b/config/.pa11yci.js
@@ -71,6 +71,7 @@ smoke.forEach((smokeConfig) => {
 for (viewport of viewports) {
 	for (url of urls) {
 		url.viewport = viewport;
+		url.verifyPage = process.env.PA11Y_VERIFY_PAGE;
 		config.urls.push(url);
 	}
 }


### PR DESCRIPTION
**CURRENTLY HOLDING OFF FROM MERGING:**
First want to diagnose + fix cause of Pa11y timing out (happening on `next-stream-page`).

cc @lc512k 

If `PA11Y_VERIFY_PAGE` is not available then it will default to `undefined` and `pa11y` will not apply the command to search for anything on the HTML.

Environment variables for user-facing apps are being set here: https://github.com/Financial-Times/next-config-vars/pull/564.