### PR TITLE
Add ecmaVersion 2017 to eslintrc.js

### DIFF
--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -6,6 +6,7 @@ const config = {
 		'node': true
 	},
 	'parserOptions': {
+		'ecmaVersion': 8,
 		'sourceType': 'module'
 	},
 	'rules': {

--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -6,7 +6,7 @@ const config = {
 		'node': true
 	},
 	'parserOptions': {
-		'ecmaVersion': 8,
+		'ecmaVersion': 2017,
 		'sourceType': 'module'
 	},
 	'rules': {


### PR DESCRIPTION
Will allow us to use `async await` syntax without `make verify` throwing a wobbly.