### PR TITLE
More robust n-ui version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ ifneq ($(CIRCLE_BUILD_NUM),)
 # The app is using n-ui
 ifneq ($(shell grep -s -Fim 1 n-ui bower.json),)
 # versions in package.json and bower.json are not equal
-ifneq ($(shell grep -s -Fim 1 \"version\" bower_components/n-ui/.bower.json | sed s/,//),$(shell grep -s -Fim 1 \"version\" node_modules/@financial-times/n-ui/package.json | sed s/,//))
+ifneq ($(shell awk '$$1 == "\"version\":" {print $$2}' bower_components/n-ui/.bower.json | grep -Eo '[0-9\.]+'),$(shell awk '$$1 == "\"version\":" {print $$2}'  node_modules/@financial-times/n-ui/package.json | grep -Eo '[0-9\.]+'))
 	$(error 'Projects using n-ui must maintain parity between versions. Rebuild without cache and update your bower.json and package.json if necessary')
 endif
 endif


### PR DESCRIPTION
Currently it matches _any_ key in the json file that has the word "version". 

(package.json can contains `_nodeVersion` and `_npmVersion`)

@wheresrhys  