### PR TITLE
eslint doesn't test '.hidden' files by default. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ heroku-cli:
 # VERIFY SUB-TASKS
 
 _verify_eslint:
-	@if [ -e .eslintrc.js ]; then $(call GLOB,'*.js') | xargs eslint && $(DONE); fi
+	@if [ -e .eslintrc.js ]; then $(call GLOB,'*.js') | xargs eslint --ignore-pattern '!' && $(DONE); fi
 
 _verify_lintspaces:
 	@if [ -e .editorconfig ] && [ -e package.json ]; then $(call GLOB) | xargs lintspaces -e .editorconfig -i js-comments -i html-comments && $(DONE); fi


### PR DESCRIPTION
Added `--ignore-pattern` flag to make sure eslint lints all files (e.g. .pa11yci.js).

![image](https://cloud.githubusercontent.com/assets/224547/22931988/a46d9e4c-f2be-11e6-9e00-00349174a908.png)

(see: https://github.com/eslint/eslint/blob/master/lib/cli-engine.js#L310)