### PR TITLE
nightly build flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,3 +213,10 @@ hel%: ## help: Show this help message.
 	@echo ""
 	@echo "targets:"
 	@grep -Eh '^.+:\ ##\ .+' ${MAKEFILE_LIST} | cut -d ' ' -f '3-' | column -t -s ':'
+
+deploy-by-day:
+ifeq ($(FT_NIGHTLY_BUILD),)
+	$(MAKE) deploy
+else
+	echo "Nightly build - exiting before deploy"
+endif

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,7 @@ hel%: ## help: Show this help message.
 	@echo "targets:"
 	@grep -Eh '^.+:\ ##\ .+' ${MAKEFILE_LIST} | cut -d ' ' -f '3-' | column -t -s ':'
 
+# Wrapper for make deploy which prevents it running when build is a nightly
 deploy-by-day:
 ifeq ($(FT_NIGHTLY_BUILD),)
 	$(MAKE) deploy


### PR DESCRIPTION
To follow this I will write a script which, 

- for every repo's circle ci does a find and replace of `make deploy` with `make deploy-by-day`
- appends the contents of this PR to every repo's n.makefile

This is the cleanest way I can think of to add it to every repo without leaving anything that won't automatically get cleaned up. Any better ideas?

@adambraimbridge I think an approach like this could also work for making the build slower downer work locally too
