### PR TITLE
Eslint 2017 parser

### DIFF
--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -6,6 +6,7 @@ const config = {
 		'node': true
 	},
 	'parserOptions': {
+		"ecmaVersion": 2017,
 		'sourceType': 'module'
 	},
 	'rules': {


### PR DESCRIPTION
Means it doesn't freak out over `async`/`await`