### PR TITLE
Amend: set sourcepoint flag to off for a11y tests

### DIFF
--- a/config/.pa11yci.js
+++ b/config/.pa11yci.js
@@ -20,7 +20,7 @@ const config = {
 
 // Override with project specifics, if any
 const exceptions = process.env.PA11Y_ROUTE_EXCEPTIONS ? process.env.PA11Y_ROUTE_EXCEPTIONS.split(',') : [];
-config.defaults.page.headers = process.env.PA11Y_HEADERS ? JSON.parse(process.env.PA11Y_HEADERS) : {Cookie: 'next-flags=ads:off,cookieMessage:off; secure=true'};
+config.defaults.page.headers = process.env.PA11Y_HEADERS ? JSON.parse(process.env.PA11Y_HEADERS) : {Cookie: 'next-flags=ads:off,sourcepoint:off,cookieMessage:off; secure=true'};
 config.defaults.hideElements = process.env.PA11Y_HIDE ? `${process.env.PA11Y_HIDE},${config.defaults.hideElements}` : config.defaults.hideElements;
 
 console.log('PA11Y_ROUTE_EXCEPTIONS:', process.env.PA11Y_ROUTE_EXCEPTIONS);


### PR DESCRIPTION
cc: @lc512k 

The adblock checker (sourcepoint) is being rolled out more widely (previously was a sample). It uses dummy pixels to identify whether adblocker in place. Whilst these pixels get removed once adblock check is completed, there have been occasions when the a11y test runs whilst they are still there.

Turning the flag off in this way should ensure that this doesn't happen.
