### PR TITLE
[Update] added pa11y rule to check headings

### DIFF
--- a/config/.pa11yci.js
+++ b/config/.pa11yci.js
@@ -13,7 +13,8 @@ const config = {
 	defaults: {
 		page: {},
 		timeout: 50000,
-		hideElements: 'iframe[src*=google],iframe[src*=proxy]'
+		hideElements: 'iframe[src*=google],iframe[src*=proxy]',
+		rules: ['Principle1.Guideline1_3.1_3_1_AAA']
 	},
 	urls: []
 }


### PR DESCRIPTION
- adds `rules` config to `.pa11yci.js`
- adds check for 'Principle1.Guideline1_3.1_3_1_AAA' (headings) on top WCAG2AA