### PR TITLE
get .env using vault instead of config-vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,18 @@ ENV_MSG_CANT_GET = "Error: Cannot get config vars for this service. Check you ar
 	@if [ ! -z $(CIRCLECI) ]; then (echo $(ENV_MSG_CIRCLECI) && exit 1); fi
 	@$(call CONFIG_VARS,development,env) > .env && perl -pi -e 's/="(.*)"/=\1/' .env && $(DONE) || (echo $(ENV_MSG_CANT_GET) && rm .env && exit 1);
 
+# replace .env with this .env2 when you want to use the vault instead of config-vars
+.env2:
+	@if [[ $(shell grep --count *.env* .gitignore) -eq 0 ]]; then (echo $(ENV_MSG_IGNORE_ENV) && exit 1); fi
+	@if [ ! -e package.json ]; then (echo $(ENV_MSG_PACKAGE_JSON) && exit 1); fi
+	@if [ ! -z $(CIRCLECI) ]; then (echo $(ENV_MSG_CIRCLECI) && exit 1); fi
+# get development config from the vault
+# - the tail command removes the first three lines (vault metadata)
+# - the 1st sed command removes the last line (empty line)
+# - the 2nd sed command changes remaining lines to key=value format
+	@vault auth --method github && vault read secret/teams/next/$(APP_NAME)/development | tail -n +4 | sed -e '$$ d' | sed -E 's/^([^ ]*)[[:blank:]]*([^ ].*)$$/\1=\2/' > .env
+	@$(DONE)
+
 MSG_HEROKU_CLI = "Please make sure the Heroku CLI toolbelt is installed - see https://toolbelt.heroku.com/. And make sure you are authenticated by running ‘heroku login’. If this is not an app, delete Procfile."
 heroku-cli:
 	@if [ -e Procfile ]; then heroku auth:whoami &>/dev/null || (echo $(MSG_HEROKU_CLI) && exit 1); fi

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ ENV_MSG_CANT_GET = "Error: Cannot get config vars for this service. Check you ar
 	@$(call CONFIG_VARS,development,env) > .env && perl -pi -e 's/="(.*)"/=\1/' .env && $(DONE) || (echo $(ENV_MSG_CANT_GET) && rm .env && exit 1);
 
 # replace .env with this .env2 when you want to use the vault instead of config-vars
-.env2:
+.env-vault:
 	@if [[ $(shell grep --count *.env* .gitignore) -eq 0 ]]; then (echo $(ENV_MSG_IGNORE_ENV) && exit 1); fi
 	@if [ ! -e package.json ]; then (echo $(ENV_MSG_PACKAGE_JSON) && exit 1); fi
 	@if [ ! -z $(CIRCLECI) ]; then (echo $(ENV_MSG_CIRCLECI) && exit 1); fi

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,12 @@ ENV_MSG_CANT_GET = "Error: Cannot get config vars for this service. Check you ar
 # - the tail command removes the first three lines (vault metadata)
 # - the 1st sed command removes the last line (empty line)
 # - the 2nd sed command changes remaining lines to key=value format
-	@vault auth --method github && vault read secret/teams/next/$(APP_NAME)/development | tail -n +4 | sed -e '$$ d' | sed -E 's/^([^ ]*)[[:blank:]]*([^ ].*)$$/\1=\2/' > .env
+	@vault auth --method github \
+		&& vault read secret/teams/next/$(APP_NAME)/development \
+		| tail -n +4 \
+		| sed -e '$$ d' \
+		| sed -E 's/^([^ ]*)[[:blank:]]*([^ ].*)$$/\1=\2/' \
+		> .env
 	@$(DONE)
 
 MSG_HEROKU_CLI = "Please make sure the Heroku CLI toolbelt is installed - see https://toolbelt.heroku.com/. And make sure you are authenticated by running ‘heroku login’. If this is not an app, delete Procfile."


### PR DESCRIPTION
same as `.env`, only difference is that we get config from vault instead of config-vars

to use, one would need to have vault installed and the vault credentials setup