### PR TITLE
Merge cookies pa11y

### DIFF
--- a/config/.pa11yci.js
+++ b/config/.pa11yci.js
@@ -73,7 +73,7 @@ config.defaults.page.headers['FT-Next-Backend-Key'] = process.env.FT_NEXT_BACKEN
 
 
 smoke.forEach((smokeConfig) => {
-	for (url in smokeConfig.urls) {
+	for (let url in smokeConfig.urls) {
 
 		let isException = false;
 
@@ -110,8 +110,8 @@ smoke.forEach((smokeConfig) => {
 	}
 });
 
-for (viewport of viewports) {
-	for (url of urls) {
+for (let viewport of viewports) {
+	for (let url of urls) {
 		url.viewport = viewport;
 		config.urls.push(url);
 	}

--- a/config/.pa11yci.js
+++ b/config/.pa11yci.js
@@ -23,14 +23,15 @@ const DEFAULT_FLAGS = 'ads:off,sourcepoint:off,cookieMessage:off';
 // Add any global config (inc headers) here
 const config = {
 	defaults: {
-		page: {},
+		page: {
+			headers: {
+				'Cookie': DEFAULT_COOKIE,
+				'FT-Flags': DEFAULT_FLAGS
+			}
+		},
 		timeout: 50000,
 		hideElements: 'iframe[src*=google],iframe[src*=proxy]',
-		rules: ['Principle1.Guideline1_3.1_3_1_AAA'],
-		headers: {
-			'Cookie': DEFAULT_COOKIE,
-			'FT-Flags': DEFAULT_FLAGS
-		}
+		rules: ['Principle1.Guideline1_3.1_3_1_AAA']
 	},
 	urls: []
 }

--- a/config/.pa11yci.js
+++ b/config/.pa11yci.js
@@ -39,14 +39,12 @@ config.defaults.hideElements = process.env.PA11Y_HIDE ? `${process.env.PA11Y_HID
  */
 
 const DEFAULT_COOKIE = 'next-flags=ads:off,sourcepoint:off,cookieMessage:off; secure=true';
-let builtHeaders = {
-	global: 'header'
-};
+let builtHeaders = {};
 
 // per-app headers
 if (process.env.PA11Y_HEADERS) {
 
-	builtHeaders = Object.assign({},builtHeaders, JSON.parse(process.env.PA11Y_HEADERS));
+	builtHeaders = Object.assign({}, builtHeaders, JSON.parse(process.env.PA11Y_HEADERS));
 
 	// concatenate any app-specific cookies
 	if (builtHeaders.Cookie) {
@@ -54,6 +52,8 @@ if (process.env.PA11Y_HEADERS) {
 	}
 }
 else {
+
+	// use the globaly cookies only if nothing app-specific
 	builtHeaders = {
 		Cookie: DEFAULT_COOKIE
 	};
@@ -80,12 +80,17 @@ smoke.forEach((smokeConfig) => {
 		exceptions.forEach((path) => {
 			isException = isException || url.indexOf(path) !== -1;
 		});
+
 		if (smokeConfig.urls[url] !== 200 || url === '/__health' || isException) {
 			continue;
 		}
 
 		const thisUrl = {
 			url: process.env.TEST_URL + url
+		}
+
+		if (process.env.TEST_URL.includes('local')) {
+			thisUrl.screenCapture = './pa11y_screenCapture/' + url + '.png';
 		}
 
 		// Do we have test-specific headers?

--- a/config/.pa11yci.js
+++ b/config/.pa11yci.js
@@ -92,7 +92,7 @@ smoke.forEach((smokeConfig) => {
 
 			// concatenate any test-specific cookies
 			if (smokeConfig.headers.Cookie) {
-				console.log('• merging cookies...')
+				console.log('• merging cookies...');
 
 				// Keep flags out of the cookie for easier merging
 				if (smokeConfig.headers.Cookie.indexOf('flags') !== -1) {
@@ -105,14 +105,14 @@ smoke.forEach((smokeConfig) => {
 
 			// concatenate any test-specific flags
 			if (smokeConfig.headers['FT-Flags']) {
-				console.log('• merging flags...')
+				console.log('• merging flags...');
 
 				// Set the concatenated flags
 				thisUrl.page.headers['FT-Flags'] = smokeConfig.headers['FT-Flags'] + ',' + config.defaults.page.headers['FT-Flags'];
 			}
 		}
 
-		urls.push(thisUrl)
+		urls.push(thisUrl);
 	}
 });
 
@@ -122,8 +122,5 @@ for (let viewport of viewports) {
 		config.urls.push(url);
 	}
 }
-
-
-console.log('config', JSON.stringify(config, null, 2))
 
 module.exports = config;

--- a/config/.pa11yci.js
+++ b/config/.pa11yci.js
@@ -85,7 +85,7 @@ smoke.forEach((smokeConfig) => {
 			let fullCookie;
 			let fullFlags;
 
-			// Merge the headers header
+			// Merge the headers
 			thisUrl.page.headers = Object.assign({}, config.defaults.page.headers, smokeConfig.headers);
 
 			// concatenate any test-specific cookies

--- a/config/.pa11yci.js
+++ b/config/.pa11yci.js
@@ -9,12 +9,28 @@ const smoke = require('./test/smoke.js');
 
 const urls = [];
 
+/**
+ * Headers can be set:
+ * - globally for all apps, in config.defaults.page.headers here
+ * - per test, in smoke.js
+ * Headers objects will be merged, cookies and flags will be concatenated
+ * No flags allowed inside the cookie for easier merging: use the FT-Flags header instead
+ */
+
+const DEFAULT_COOKIE = 'secure=true';
+const DEFAULT_FLAGS = 'ads:off,sourcepoint:off,cookieMessage:off';
+
+// Add any global config (inc headers) here
 const config = {
 	defaults: {
 		page: {},
 		timeout: 50000,
 		hideElements: 'iframe[src*=google],iframe[src*=proxy]',
-		rules: ['Principle1.Guideline1_3.1_3_1_AAA']
+		rules: ['Principle1.Guideline1_3.1_3_1_AAA'],
+		headers: {
+			'Cookie': DEFAULT_COOKIE,
+			'FT-Flags': DEFAULT_FLAGS
+		}
 	},
 	urls: []
 }
@@ -28,25 +44,6 @@ const exceptions = process.env.PA11Y_ROUTE_EXCEPTIONS ? process.env.PA11Y_ROUTE_
 // set per-project in PA11Y_HIDE in config-vars
 // Use with caution. May break the experience for users.
 config.defaults.hideElements = process.env.PA11Y_HIDE ? `${process.env.PA11Y_HIDE},${config.defaults.hideElements}` : config.defaults.hideElements;
-
-
-/**
- * Headers can be set:
- * - globally for all apps, in globalHeaders here
- * - per test, in smoke.js
- * Headers objects will be merged, cookies will be concatenated
- */
-
-const DEFAULT_COOKIE = 'secure=true';
-const DEFAULT_FLAGS = 'ads:off,sourcepoint:off,cookieMessage:off'
-
-// Add any global headers here
-let globalHeaders = {
-	'Cookie': DEFAULT_COOKIE,
-	'FT-Flags': DEFAULT_FLAGS
-};
-
-config.defaults.page.headers = globalHeaders;
 
 console.log('PA11Y_ROUTE_EXCEPTIONS:', process.env.PA11Y_ROUTE_EXCEPTIONS);
 console.log('exceptions:', exceptions);


### PR DESCRIPTION
@GlynnPhillips @andygnewman This will merge headers, concatenate cookies and concatenate FT-Flags separately:
- Global in .pa11yci.js
- per-test in smoke.js

cc @rowanmanning 

## Updated apps:

The following apps have been updated: removed any cookies already specified globally in n-makefile, checked pa11y tests still work, updated to the latest version of pa11y, checked pa11y screenshots, added screenshots folder to gitignore, updated build-tools, removed any lingering pa11y headers from config vars (no longer supported)

- [x] article https://github.com/Financial-Times/next-article/pull/2085 
- [x] front-page https://github.com/Financial-Times/next-front-page/pull/1544
- [x] stream-page https://github.com/Financial-Times/next-stream-page/pull/1767 *
- [x] signup https://github.com/Financial-Times/next-signup/pull/995
- [x] corp-signup https://github.com/Financial-Times/next-corp-signup/pull/39
- [x] myft-page https://github.com/Financial-Times/next-myft-page/pull/1213 
- [x] epaper https://github.com/Financial-Times/next-epaper/pull/3
- [x] static https://github.com/Financial-Times/next-static/pull/25
- [x] feedback https://github.com/Financial-Times/next-feedback/pull/81 
- [x] product https://github.com/Financial-Times/next-product/pull/325
- [ ] toggler
- [x] retention https://github.com/Financial-Times/next-retention/pull/40 *
- [x] video-page https://github.com/Financial-Times/next-video-page/pull/98 *
- [x] tour-page https://github.com/Financial-Times/next-tour-page/pull/47
- [x] errors https://github.com/Financial-Times/next-errors/pull/101